### PR TITLE
Refactor PR creation in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,14 +350,12 @@ jobs:
           ref: release-v${{ needs.increment-version.outputs.new_version }}
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          base: develop
-          branch: release-v${{ needs.increment-version.outputs.new_version }}
-          title: "Release v${{ needs.increment-version.outputs.new_version }}"
-          body: |
-            This PR merges the release v${{ needs.increment-version.outputs.new_version }} back to the develop branch.
+        run: |
+          gh pr create \
+            --base develop \
+            --head release-v${{ needs.increment-version.outputs.new_version }} \
+            --title "Release v${{ needs.increment-version.outputs.new_version }}" \
+            --body "This PR merges the release v${{ needs.increment-version.outputs.new_version }} back to the develop branch.
             
             ## Changes
             - Incremented version number from ${{ needs.increment-version.outputs.current_version }} to ${{ needs.increment-version.outputs.new_version }}
@@ -370,11 +368,13 @@ jobs:
             - ✅ Documentation (ADRs and guides)
             
             ## Available Packages
-            - `coopetition-v${{ needs.increment-version.outputs.new_version }}.zip`: Core GameScript mod
-            - `coopetition-content-v${{ needs.increment-version.outputs.new_version }}.zip`: Campaign content only
-            - `coopetition-tools-v${{ needs.increment-version.outputs.new_version }}.zip`: Development tools
-            - `coopetition-complete-v${{ needs.increment-version.outputs.new_version }}.zip`: Everything combined
-          labels: version-bump, automated-pr, monorepo-release
+            - \`coopetition-v${{ needs.increment-version.outputs.new_version }}.zip\`: Core GameScript mod
+            - \`coopetition-content-v${{ needs.increment-version.outputs.new_version }}.zip\`: Campaign content only
+            - \`coopetition-tools-v${{ needs.increment-version.outputs.new_version }}.zip\`: Development tools
+            - \`coopetition-complete-v${{ needs.increment-version.outputs.new_version }}.zip\`: Everything combined" \
+            --label "version-bump,automated-pr,monorepo-release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: PR Summary
         run: |

--- a/docs/adrs/0007-release-branch-workflow-fix.md
+++ b/docs/adrs/0007-release-branch-workflow-fix.md
@@ -39,7 +39,8 @@ We will modify the workflow to:
 
 2. **Updated `create-pr` job**:
    - Added `ref` parameter to checkout the release branch
-   - Fixed action parameter from `head` to `branch` (correct parameter for `peter-evans/create-pull-request`)
+   - Replaced `peter-evans/create-pull-request` action with GitHub CLI (`gh pr create`)
+   - This creates a PR from the existing release branch to develop without trying to modify the branch
 
 3. **Added conditional execution**:
    - All subsequent jobs (quality-gates, build-components, integration, create-pr) now skip execution when only a version bump is detected
@@ -68,6 +69,10 @@ main push → detect changes →
 ### Alternative 3: Use different PR creation action
 - **Rejected**: Current action works fine with correct parameters
 - **Reason**: No need to introduce additional dependencies
+
+### Alternative 4: Use GitHub CLI instead of peter-evans/create-pull-request
+- **Accepted**: GitHub CLI is more straightforward for creating PRs from existing branches
+- **Reason**: The peter-evans action is designed to make changes and create PRs, but we already have the changes on the release branch
 
 ## References
 - [GitHub Actions Workflow File](.github/workflows/build.yml)


### PR DESCRIPTION
- Replaced the `peter-evans/create-pull-request` action with the GitHub CLI command `gh pr create` for creating pull requests from the release branch to the develop branch.
- Updated the workflow to improve clarity and streamline the PR creation process, ensuring it does not attempt to modify the branch.
- Enhanced the documentation in the ADR to reflect the rationale for using GitHub CLI over the previous action.

These changes simplify the release process and align with best practices for GitHub Actions, resulting in a more efficient CI/CD workflow.