### PR TITLE
Migrate to browser fs with index db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,6 +6333,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserfs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.4.3.tgz",
+      "integrity": "sha512-tz8HClVrzTJshcyIu8frE15cjqjcBIu15Bezxsvl/i+6f59iNCN3kznlWjz0FEb3DlnDx3gW5szxeT6D1x0s0w==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.1.4",
+        "pako": "^1.0.4"
+      },
+      "bin": {
+        "make_xhrfs_index": "dist/scripts/make_xhrfs_index.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserfs/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
@@ -17613,6 +17638,7 @@
         "@vee-validate/zod": "^4.15.1",
         "@vueuse/core": "13.9.0",
         "@vueuse/nuxt": "13.9.0",
+        "browserfs": "^1.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "defu": "^6.1.4",

--- a/workspaces/campaign-editor/app/composables/useFileSystem.ts
+++ b/workspaces/campaign-editor/app/composables/useFileSystem.ts
@@ -6,12 +6,12 @@ import { useIsTestEnvironment } from './useIsTestEnvironment'
  * Automatically detects backend capabilities and test environment to return the correct adapter
  * Shared across multiple Vue instances to ensure consistency
  */
-function useFileSystemImpl(): FileSystemAdapter {
+function useFileSystemImpl(forceInMemory: boolean = false): FileSystemAdapter {
   const hasBackend = useHasBackend()
   const isTestEnvironment = useIsTestEnvironment()
 
-  // Create the appropriate adapter based on backend availability and test environment
-  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value)
+  // Create the appropriate adapter based on backend availability, test environment, and force parameter
+  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value, forceInMemory)
 }
 
 export const useFileSystem = createSharedComposable(useFileSystemImpl)

--- a/workspaces/campaign-editor/app/composables/useFileSystem.ts
+++ b/workspaces/campaign-editor/app/composables/useFileSystem.ts
@@ -1,15 +1,17 @@
 import type { FileSystemAdapter } from '~/types'
+import { useIsTestEnvironment } from './useIsTestEnvironment'
 
 /**
  * Composable that provides the appropriate file system adapter
- * Automatically detects backend capabilities and returns the correct adapter
+ * Automatically detects backend capabilities and test environment to return the correct adapter
  * Shared across multiple Vue instances to ensure consistency
  */
 function useFileSystemImpl(): FileSystemAdapter {
   const hasBackend = useHasBackend()
+  const isTestEnvironment = useIsTestEnvironment()
 
-  // Create the appropriate adapter based on backend availability
-  return createFileSystemAdapter(hasBackend.value)
+  // Create the appropriate adapter based on backend availability and test environment
+  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value)
 }
 
 export const useFileSystem = createSharedComposable(useFileSystemImpl)

--- a/workspaces/campaign-editor/app/composables/useFileSystem.ts
+++ b/workspaces/campaign-editor/app/composables/useFileSystem.ts
@@ -4,14 +4,15 @@ import { useIsTestEnvironment } from './useIsTestEnvironment'
 /**
  * Composable that provides the appropriate file system adapter
  * Automatically detects backend capabilities and test environment to return the correct adapter
+ * Can be forced to use in-memory adapter via NUXT_FORCE_IN_MEMORY_FS environment variable
  * Shared across multiple Vue instances to ensure consistency
  */
-function useFileSystemImpl(forceInMemory: boolean = false): FileSystemAdapter {
+function useFileSystemImpl(): FileSystemAdapter {
   const hasBackend = useHasBackend()
   const isTestEnvironment = useIsTestEnvironment()
 
-  // Create the appropriate adapter based on backend availability, test environment, and force parameter
-  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value, forceInMemory)
+  // Create the appropriate adapter based on backend availability, test environment, and runtime config
+  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value)
 }
 
 export const useFileSystem = createSharedComposable(useFileSystemImpl)

--- a/workspaces/campaign-editor/app/composables/useFileSystem.ts
+++ b/workspaces/campaign-editor/app/composables/useFileSystem.ts
@@ -11,8 +11,12 @@ function useFileSystemImpl(): FileSystemAdapter {
   const hasBackend = useHasBackend()
   const isTestEnvironment = useIsTestEnvironment()
 
+  // Get runtime config to check if we should force in-memory adapter
+  const config = useRuntimeConfig()
+  const forceInMemory = config.public.forceInMemoryFileSystem
+
   // Create the appropriate adapter based on backend availability, test environment, and runtime config
-  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value)
+  return createFileSystemAdapter(hasBackend.value, isTestEnvironment.value, forceInMemory)
 }
 
 export const useFileSystem = createSharedComposable(useFileSystemImpl)

--- a/workspaces/campaign-editor/app/composables/useInMemoryFileSystem.ts
+++ b/workspaces/campaign-editor/app/composables/useInMemoryFileSystem.ts
@@ -1,0 +1,13 @@
+import type { FileSystemAdapter } from '~/types'
+import { InMemFileSystemAdapter } from '~/utils/fileSystem/index'
+
+/**
+ * Composable that provides the in-memory file system adapter
+ * Always returns the InMemFileSystemAdapter regardless of environment
+ * Useful for testing or when you specifically need in-memory storage
+ */
+function useInMemoryFileSystemImpl(): FileSystemAdapter {
+  return new InMemFileSystemAdapter()
+}
+
+export const useInMemoryFileSystem = createSharedComposable(useInMemoryFileSystemImpl)

--- a/workspaces/campaign-editor/app/composables/useIsTestEnvironment.ts
+++ b/workspaces/campaign-editor/app/composables/useIsTestEnvironment.ts
@@ -1,0 +1,21 @@
+/**
+ * Composable to detect if we're running in a test environment
+ * Returns true if running in test mode (Jest, Vitest, etc.)
+ * Uses useState to prevent hydration mismatches
+ */
+export const useIsTestEnvironment = () => {
+  return useState('isTestEnvironment', () => {
+    // Check for common test environment indicators
+    if (import.meta.server) {
+      return process.env.NODE_ENV === 'test' ||
+        process.env.VITEST === 'true' ||
+        process.env.JEST_WORKER_ID !== undefined ||
+        process.env.NODE_ENV === 'development' && process.env.TEST === 'true'
+    }
+
+    // Client-side detection
+    return import.meta.env.MODE === 'test' ||
+      import.meta.env.VITEST === 'true' ||
+      import.meta.env.DEV && import.meta.env.TEST === 'true'
+  })
+}

--- a/workspaces/campaign-editor/app/utils/fileSystem.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem.ts
@@ -1,5 +1,5 @@
 import { FileSystemFeature } from '~/types'
-import { BackendFileSystemAdapter, BrowserFSFileSystemAdapter } from './fileSystem/index'
+import { BackendFileSystemAdapter, BrowserFSFileSystemAdapter, InMemFileSystemAdapter } from './fileSystem/index'
 import type { FileSystemAdapter, FeatureZipImport, FeatureZipExport } from '~/types'
 
 // Type guards for feature detection
@@ -12,7 +12,12 @@ export function hasFeatureZipExport<T extends FileSystemAdapter>(fs: T): fs is T
 }
 
 // Factory function to create the appropriate adapter
-export function createFileSystemAdapter(hasBackend: boolean): FileSystemAdapter {
+export function createFileSystemAdapter(hasBackend: boolean, isTestEnvironment: boolean = false): FileSystemAdapter {
   // Use hasBackend parameter to detect if we have backend capabilities
-  return hasBackend ? new BackendFileSystemAdapter() : new BrowserFSFileSystemAdapter()
+  if (hasBackend) {
+    return new BackendFileSystemAdapter()
+  }
+
+  // For browser environments, choose between in-memory (tests) and BrowserFS (production)
+  return isTestEnvironment ? new InMemFileSystemAdapter() : new BrowserFSFileSystemAdapter()
 }

--- a/workspaces/campaign-editor/app/utils/fileSystem.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem.ts
@@ -12,7 +12,16 @@ export function hasFeatureZipExport<T extends FileSystemAdapter>(fs: T): fs is T
 }
 
 // Factory function to create the appropriate adapter
-export function createFileSystemAdapter(hasBackend: boolean, isTestEnvironment: boolean = false): FileSystemAdapter {
+export function createFileSystemAdapter(
+  hasBackend: boolean,
+  isTestEnvironment: boolean = false,
+  forceInMemory: boolean = false
+): FileSystemAdapter {
+  // Force in-memory adapter if requested (useful for testing or specific use cases)
+  if (forceInMemory) {
+    return new InMemFileSystemAdapter()
+  }
+
   // Use hasBackend parameter to detect if we have backend capabilities
   if (hasBackend) {
     return new BackendFileSystemAdapter()

--- a/workspaces/campaign-editor/app/utils/fileSystem.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem.ts
@@ -14,13 +14,10 @@ export function hasFeatureZipExport<T extends FileSystemAdapter>(fs: T): fs is T
 // Factory function to create the appropriate adapter
 export function createFileSystemAdapter(
   hasBackend: boolean,
-  isTestEnvironment: boolean = false
+  isTestEnvironment: boolean = false,
+  forceInMemory: boolean = false
 ): FileSystemAdapter {
-  // Get runtime config to check if we should force in-memory adapter
-  const config = useRuntimeConfig()
-  const forceInMemory = config.public.forceInMemoryFileSystem
-
-  // Force in-memory adapter if requested via runtime config
+  // Force in-memory adapter if requested (useful for testing or specific use cases)
   if (forceInMemory) {
     return new InMemFileSystemAdapter()
   }

--- a/workspaces/campaign-editor/app/utils/fileSystem.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem.ts
@@ -14,10 +14,13 @@ export function hasFeatureZipExport<T extends FileSystemAdapter>(fs: T): fs is T
 // Factory function to create the appropriate adapter
 export function createFileSystemAdapter(
   hasBackend: boolean,
-  isTestEnvironment: boolean = false,
-  forceInMemory: boolean = false
+  isTestEnvironment: boolean = false
 ): FileSystemAdapter {
-  // Force in-memory adapter if requested (useful for testing or specific use cases)
+  // Get runtime config to check if we should force in-memory adapter
+  const config = useRuntimeConfig()
+  const forceInMemory = config.public.forceInMemoryFileSystem
+
+  // Force in-memory adapter if requested via runtime config
   if (forceInMemory) {
     return new InMemFileSystemAdapter()
   }

--- a/workspaces/campaign-editor/app/utils/fileSystem.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem.ts
@@ -1,5 +1,5 @@
 import { FileSystemFeature } from '~/types'
-import { BackendFileSystemAdapter, InMemFileSystemAdapter } from './fileSystem/index'
+import { BackendFileSystemAdapter, BrowserFSFileSystemAdapter } from './fileSystem/index'
 import type { FileSystemAdapter, FeatureZipImport, FeatureZipExport } from '~/types'
 
 // Type guards for feature detection
@@ -14,5 +14,5 @@ export function hasFeatureZipExport<T extends FileSystemAdapter>(fs: T): fs is T
 // Factory function to create the appropriate adapter
 export function createFileSystemAdapter(hasBackend: boolean): FileSystemAdapter {
   // Use hasBackend parameter to detect if we have backend capabilities
-  return hasBackend ? new BackendFileSystemAdapter() : new InMemFileSystemAdapter()
+  return hasBackend ? new BackendFileSystemAdapter() : new BrowserFSFileSystemAdapter()
 }

--- a/workspaces/campaign-editor/app/utils/fileSystem/BrowserFSFileSystemAdapter.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem/BrowserFSFileSystemAdapter.ts
@@ -7,7 +7,8 @@ import * as BrowserFS from 'browserfs'
 
 // BrowserFS adapter using IndexedDB backend
 export class BrowserFSFileSystemAdapter implements FileSystemAdapter, FeatureZipImport, FeatureZipExport {
-  private fs: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private fs: any // BrowserFS provides a different interface than Node.js fs
   private initialized = false
 
   constructor() {

--- a/workspaces/campaign-editor/app/utils/fileSystem/BrowserFSFileSystemAdapter.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem/BrowserFSFileSystemAdapter.ts
@@ -1,0 +1,329 @@
+import type { AnyEntity, FileSystemAdapter, Storable, EntityFile, FeatureZipImport, FeatureZipExport } from '~/types'
+import { FileSystemFeature } from '~/types'
+import { parse as parseYAML, stringify as stringifyYAML } from 'yaml'
+import JSZip from 'jszip'
+import { saveAs } from 'file-saver'
+import * as BrowserFS from 'browserfs'
+
+// BrowserFS adapter using IndexedDB backend
+export class BrowserFSFileSystemAdapter implements FileSystemAdapter, FeatureZipImport, FeatureZipExport {
+  private fs: any
+  private initialized = false
+
+  constructor() {
+    this.initializeBrowserFS()
+  }
+
+  private async initializeBrowserFS(): Promise<void> {
+    if (this.initialized) return
+
+    return new Promise((resolve, reject) => {
+      BrowserFS.configure({
+        fs: 'IndexedDB',
+        options: {
+          storeName: 'campaignFileSystem'
+        }
+      }, (err) => {
+        if (err) {
+          console.error('Failed to initialize BrowserFS:', err)
+          reject(err)
+          return
+        }
+
+        this.fs = BrowserFS.BFSRequire('fs')
+        this.initialized = true
+        resolve()
+      })
+    })
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.initializeBrowserFS()
+    }
+  }
+
+  async load<T extends AnyEntity>(path: string): Promise<Storable<T> | undefined> {
+    await this.ensureInitialized()
+
+    try {
+      if (!this.fs.existsSync(path)) {
+        return undefined
+      }
+
+      const content = this.fs.readFileSync(path, 'utf8')
+      return parseYAML(content) as Storable<T>
+    } catch (error) {
+      console.warn(`Failed to load entity from ${path}:`, error)
+      return undefined
+    }
+  }
+
+  async save<T extends AnyEntity>(entityFile: EntityFile<T>): Promise<void> {
+    await this.ensureInitialized()
+
+    try {
+      // Ensure directory exists
+      const dir = this.fs.dirname(entityFile.path)
+      if (!this.fs.existsSync(dir)) {
+        this.fs.mkdirSync(dir, { recursive: true })
+      }
+
+      const content = stringifyYAML(entityFile.storable)
+      this.fs.writeFileSync(entityFile.path, content, 'utf8')
+    } catch (error) {
+      console.error(`Failed to save entity to ${entityFile.path}:`, error)
+      throw error
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    await this.ensureInitialized()
+
+    try {
+      if (this.fs.existsSync(path)) {
+        this.fs.unlinkSync(path)
+      }
+    } catch (error) {
+      console.error(`Failed to delete ${path}:`, error)
+      throw error
+    }
+  }
+
+  async loadAll<T extends AnyEntity>(pattern: string): Promise<Storable<T>[]> {
+    await this.ensureInitialized()
+
+    try {
+      const entityTypes = this.parsePattern(pattern)
+      const allEntities: Storable<T>[] = []
+
+      // Load entities based on pattern
+      if (entityTypes.has('campaigns') || pattern === '*' || pattern.includes('campaigns')) {
+        const campaigns = await this.loadEntitiesFromDirectory('campaigns', 'Campaign')
+        allEntities.push(...(campaigns as Storable<T>[]))
+      }
+
+      if (entityTypes.has('goals') || pattern === '*' || pattern.includes('goals')) {
+        const goals = await this.loadEntitiesFromDirectory('goals', 'Goal')
+        allEntities.push(...(goals as Storable<T>[]))
+      }
+
+      if (entityTypes.has('scenarios') || pattern === '*' || pattern.includes('scenarios')) {
+        const scenarios = await this.loadEntitiesFromDirectory('scenarios', 'Scenario')
+        allEntities.push(...(scenarios as Storable<T>[]))
+      }
+
+      if (entityTypes.has('manifest') || pattern === '*' || pattern.includes('manifest')) {
+        const manifest = await this.load('manifest.yaml')
+        if (manifest) {
+          allEntities.push(manifest as Storable<T>)
+        }
+      }
+
+      return allEntities
+    } catch (error) {
+      console.warn('Failed to load all entities:', error)
+      return []
+    }
+  }
+
+  supports(feature: FileSystemFeature): boolean {
+    switch (feature) {
+      case FileSystemFeature.ZIP_IMPORT:
+        return true // BrowserFS adapter supports ZIP import
+      case FileSystemFeature.ZIP_EXPORT:
+        return true // BrowserFS adapter supports ZIP export
+      case FileSystemFeature.WATCH:
+        return false // BrowserFS doesn't support watching in this implementation
+      case FileSystemFeature.PERSISTENCE:
+        return true // BrowserFS supports persistence via IndexedDB
+      default:
+        return false
+    }
+  }
+
+  // ZIP export functionality
+  async exportAll(): Promise<Blob> {
+    await this.ensureInitialized()
+
+    const zip = new JSZip()
+
+    try {
+      // Group entities by type for folder structure
+      const campaigns = await this.loadEntitiesFromDirectory('campaigns', 'Campaign')
+      const goals = await this.loadEntitiesFromDirectory('goals', 'Goal')
+      const scenarios = await this.loadEntitiesFromDirectory('scenarios', 'Scenario')
+      const manifest = await this.load('manifest.yaml')
+
+      // Add campaigns
+      if (campaigns.length > 0) {
+        const campaignsFolder = zip.folder('campaigns')
+        for (const campaign of campaigns) {
+          const yamlContent = stringifyYAML(campaign)
+          campaignsFolder?.file(`${campaign.__meta.filename}`, yamlContent)
+        }
+      }
+
+      // Add goals
+      if (goals.length > 0) {
+        const goalsFolder = zip.folder('goals')
+        for (const goal of goals) {
+          const yamlContent = stringifyYAML(goal)
+          goalsFolder?.file(`${goal.__meta.filename}`, yamlContent)
+        }
+      }
+
+      // Add scenarios
+      if (scenarios.length > 0) {
+        const scenariosFolder = zip.folder('scenarios')
+        for (const scenario of scenarios) {
+          const yamlContent = stringifyYAML(scenario)
+          scenariosFolder?.file(`${scenario.__meta.filename}`, yamlContent)
+        }
+      }
+
+      // Add manifest
+      if (manifest) {
+        const manifestContent = stringifyYAML(manifest)
+        zip.file('manifest.yaml', manifestContent)
+      }
+
+      return await zip.generateAsync({ type: 'blob' })
+    } catch (error) {
+      console.error('Failed to export all entities:', error)
+      throw error
+    }
+  }
+
+  // ZIP import functionality
+  async importFromZip(file: File): Promise<void> {
+    await this.ensureInitialized()
+
+    try {
+      const zip = new JSZip()
+      const zipContents = await zip.loadAsync(file)
+
+      // Clear existing data
+      await this.clearAllData()
+
+      // Process each file in the ZIP
+      for (const [filename, zipFile] of Object.entries(zipContents.files)) {
+        if (zipFile.dir) continue
+
+        const content = await zipFile.async('text')
+        const yamlData = parseYAML(content)
+
+        // Determine the path based on the file location
+        let path: string
+        if (filename.startsWith('campaigns/')) {
+          path = `campaigns/${filename.replace('campaigns/', '')}`
+        } else if (filename.startsWith('goals/')) {
+          path = `goals/${filename.replace('goals/', '')}`
+        } else if (filename.startsWith('scenarios/')) {
+          path = `scenarios/${filename.replace('scenarios/', '')}`
+        } else if (filename === 'manifest.yaml') {
+          path = 'manifest.yaml'
+        } else {
+          continue // Skip unknown files
+        }
+
+        // Ensure directory exists
+        const dir = this.fs.dirname(path)
+        if (!this.fs.existsSync(dir)) {
+          this.fs.mkdirSync(dir, { recursive: true })
+        }
+
+        this.fs.writeFileSync(path, stringifyYAML(yamlData), 'utf8')
+      }
+    } catch (error) {
+      console.error('Failed to import from ZIP:', error)
+      throw error
+    }
+  }
+
+  async downloadExport(filename = 'campaigns.zip'): Promise<void> {
+    const blob = await this.exportAll()
+    saveAs(blob, filename)
+  }
+
+  private async loadEntitiesFromDirectory<T extends AnyEntity>(directory: string, entityType: string): Promise<Storable<T>[]> {
+    const entities: Storable<T>[] = []
+
+    try {
+      if (!this.fs.existsSync(directory)) {
+        return entities
+      }
+
+      const files = this.fs.readdirSync(directory)
+
+      for (const file of files) {
+        if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+          const filePath = `${directory}/${file}`
+          const entity = await this.load<T>(filePath)
+          if (entity && entity.__type === entityType) {
+            entities.push(entity)
+          }
+        }
+      }
+    } catch (error) {
+      console.warn(`Failed to load entities from ${directory}:`, error)
+    }
+
+    return entities
+  }
+
+  private async clearAllData(): Promise<void> {
+    try {
+      // Remove all directories and files
+      const rootContents = this.fs.readdirSync('/')
+
+      for (const item of rootContents) {
+        const itemPath = `/${item}`
+        if (this.fs.statSync(itemPath).isDirectory()) {
+          this.fs.rmSync(itemPath, { recursive: true, force: true })
+        } else {
+          this.fs.unlinkSync(itemPath)
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to clear all data:', error)
+    }
+  }
+
+  private parsePattern(pattern: string): Set<string> {
+    const entityTypes = new Set<string>()
+
+    // Handle wildcard patterns
+    if (pattern === '*' || pattern === '**/*') {
+      entityTypes.add('campaigns')
+      entityTypes.add('goals')
+      entityTypes.add('scenarios')
+      entityTypes.add('manifest')
+      return entityTypes
+    }
+
+    // Parse specific patterns
+    if (pattern.includes('campaigns') || pattern.includes('campaign')) {
+      entityTypes.add('campaigns')
+    }
+    if (pattern.includes('goals') || pattern.includes('goal')) {
+      entityTypes.add('goals')
+    }
+    if (pattern.includes('scenarios') || pattern.includes('scenario')) {
+      entityTypes.add('scenarios')
+    }
+    if (pattern.includes('manifest')) {
+      entityTypes.add('manifest')
+    }
+
+    // If no specific patterns matched, default to all
+    if (entityTypes.size === 0) {
+      entityTypes.add('campaigns')
+      entityTypes.add('goals')
+      entityTypes.add('scenarios')
+      entityTypes.add('manifest')
+    }
+
+    return entityTypes
+  }
+}

--- a/workspaces/campaign-editor/app/utils/fileSystem/index.ts
+++ b/workspaces/campaign-editor/app/utils/fileSystem/index.ts
@@ -1,3 +1,4 @@
 // Re-export everything from the adapter files
 export * from './BackendFileSystemAdapter'
 export * from './InMemFileSystemAdapter'
+export * from './BrowserFSFileSystemAdapter'

--- a/workspaces/campaign-editor/nuxt.config.ts
+++ b/workspaces/campaign-editor/nuxt.config.ts
@@ -69,6 +69,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       baseUrl: process.env.NUXT_BASE_URL || '/',
+      forceInMemoryFileSystem: process.env.NUXT_FORCE_IN_MEMORY_FS === 'true',
     },
   },
 

--- a/workspaces/campaign-editor/package.json
+++ b/workspaces/campaign-editor/package.json
@@ -47,6 +47,7 @@
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "13.9.0",
     "@vueuse/nuxt": "13.9.0",
+    "browserfs": "^1.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "defu": "^6.1.4",


### PR DESCRIPTION
Replace the in-memory file adapter with a BrowserFS (IndexedDB) implementation for persistent and scalable storage in browser-only mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cf20c7d-146a-4b47-be42-42fa3deb97d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2cf20c7d-146a-4b47-be42-42fa3deb97d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

